### PR TITLE
Fixes export cleverList.

### DIFF
--- a/components/cleverList/index.js
+++ b/components/cleverList/index.js
@@ -247,7 +247,7 @@ class CleverListComp extends React.Component{
       height={itemSized() * itemsVisible}
       itemCount={items.length}
       itemSize={itemSized}>{this.fullRender(items)}</List>
- 
+
   }
 
   render(){
@@ -270,5 +270,5 @@ class CleverListComp extends React.Component{
 
 export const CleverList = CleverListComp;
 export default CleverList;
-export cleverlistMD from './cleverlist.md.js';
-export cleverlistEX from './cleverlist.ex.md.js';
+export cleverlistMD from './cleverList.md.js';
+export cleverlistEX from './cleverList.ex.md.js';

--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 export BigLoader from './components/bigLoader';
 export Checkbox from './components/checkbox';
-export CleverList from './cleverList';
+export CleverList from './components/cleverList';
 export {Dropdown, MenuItem, OptionsMenu} from './components/dropdown';
 export {FormTabs, FormTab} from './components/formTabs';
 // export KeyValue from './components/keyValue';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ns1-gui",
-  "version": "1.0.32",
+  "version": "1.0.34",
   "description": "React component toolset for building interfaces that use the same patterns as the NS1 Portal.",
   "main": "demo.js",
   "scripts": {


### PR DESCRIPTION
Before it was returning the following error on our import in daitan/web.

![Screenshot from 2020-10-28 09-47-49](https://user-images.githubusercontent.com/6593889/97449905-eb225900-1910-11eb-9d46-88c5158a9192.png)

With this fix, we successfully imported the library.